### PR TITLE
resolve error with API token

### DIFF
--- a/packer/supabase.pkr.hcl
+++ b/packer/supabase.pkr.hcl
@@ -53,6 +53,7 @@ source "digitalocean" "supabase" {
   snapshot_name = local.snapshot_name
   tags          = local.tags
   ssh_username  = "root"
+  api_token     = var.do_token
 }
 
 build {


### PR DESCRIPTION
When trying to `packer build .` there is an error that the TF module does not have the `api_token` set. 