### PR TITLE
Change Droplet Image to Ubuntu 22.04

### DIFF
--- a/packer/supabase.pkr.hcl
+++ b/packer/supabase.pkr.hcl
@@ -25,7 +25,7 @@ variable "region" {
 variable "droplet_image" {
   description = "The Droplet image ID or slug. This could be either image ID or droplet snapshot ID."
   type        = string
-  default     = "ubuntu-22-10-x64"
+  default     = "ubuntu-22-04-x64"
 }
 
 variable "droplet_size" {


### PR DESCRIPTION
Addresses issues #52 and #53

Image for Ubuntu 22.10 does not exist, and 23.10 does not have docker-ce available via apt