### PR TITLE
Make dedicated spaces storage region

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -6,7 +6,7 @@ resource "random_id" "bucket" {
 
 resource "digitalocean_spaces_bucket" "this" {
   name   = random_id.bucket.hex
-  region = var.region
+  region = var.storage_region
 }
 
 resource "digitalocean_spaces_bucket_policy" "this" {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -10,6 +10,7 @@ spaces_secret_access_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 ## REQUIRED ##
 region    = "ams3"
+storage_region    = "ams3"
 domain    = "example.com"
 timezone  = "Europe/Amsterdam"
 auth_user = "admin"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,11 @@ variable "region" {
   type        = string
 }
 
+variable "storage_region" {
+  description = "The region where the DO Space will be created."
+  type        = string
+}
+
 variable "domain" {
   description = "Domain name where the Supabase instance is accessible. The final domain will be of the format `supabase.example.com`"
   type        = string


### PR DESCRIPTION
DO spaces are not available in all regions, so allow setting regions for spaces independently from droplets/volumes

