### PR TITLE
escape paths in sendgrid provisioning

### DIFF
--- a/terraform/sendgrid.tf
+++ b/terraform/sendgrid.tf
@@ -4,7 +4,7 @@
 ############
 resource "null_resource" "sendgrid_single_sender" {
   provisioner "local-exec" {
-    command = "cp .\/files\/sender-verification.sh.tmpl .\/files\/sender-verification.sh && chmod +x .\/files\/sender-verification.sh && .\/files\/sender-verification.sh"
+    command = "cp .\\files\\sender-verification.sh.tmpl .\\files\\sender-verification.sh && chmod +x .\\files\\sender-verification.sh && .\\files\\sender-verification.sh"
 
     environment = {
       API           = var.sendgrid_api

--- a/terraform/sendgrid.tf
+++ b/terraform/sendgrid.tf
@@ -4,7 +4,7 @@
 ############
 resource "null_resource" "sendgrid_single_sender" {
   provisioner "local-exec" {
-    command = "cp ./files/sender-verification.sh.tmpl ./files/sender-verification.sh && chmod +x ./files/sender-verification.sh && ./files/sender-verification.sh"
+    command = "cp .\/files\/sender-verification.sh.tmpl .\/files\/sender-verification.sh && chmod +x .\/files\/sender-verification.sh && .\/files\/sender-verification.sh"
 
     environment = {
       API           = var.sendgrid_api


### PR DESCRIPTION
https://github.com/digitalocean/supabase-on-do/blob/0a4c42b341adc9500f3b248616ab36871b7f3637/terraform/sendgrid.tf#L7

The above line does not work in instances such as using Git Bash as your shell under windows, not in CMD, as referenced in issue #31